### PR TITLE
spec/: There is no unit testing. Install jasmine and initialize it. C…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "eslint": "^3.16.1",
+		"jasmine": "^2.5.3",
     "winston": "^2.3.1"
   }
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}

--- a/spec/timestampSpec.js
+++ b/spec/timestampSpec.js
@@ -1,21 +1,49 @@
 var timestamp = require('../app/api/timestamp.js');
 
 describe('timestamp', function () {
+	// Create date object based off of test value to ensure both our expected
+	// and actual timestamps are in the same timezone
+	var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+	var dateTestObj;
+	var	createDateTestObj = function(dateInput, type) {
+		let date;
+		if (type == 'unix') {
+			date = new Date(Math.floor(dateInput * 1000));
+		} else {
+			date = new Date(dateInput);
+		}
+
+		if (date == 'Invalid Date') {
+			dateTestObj = {
+				unix: null,
+				natural: null
+			};
+		} else {
+			dateTestObj = {
+				unix: Math.floor(date.getTime() / 1000),
+				natural: months[date.getMonth()] + ' ' + date.getDate() + ', ' + date.getFullYear()
+			};
+		}
+		return dateTestObj;
+	};
+
 	it('returns an object', function() {
 		var result = timestamp();
 		expect(typeof(result)).toEqual('object');
 	});
 
 	it('given no agrument returns an object with keys unix and natural with null values', function (done) {
+		var expectation = createDateTestObj();
 		timestamp().then(function(data) {
-			expect(data).toEqual({unix: null, natural: null});
+			expect(data).toEqual(expectation);
 			done();
 		});
 	})
 
 	it('given "1484006400" returns an object with "unix" value of "1484006400" and a natural value of "January 10, 2017"', function (done) {
+		var expectation = createDateTestObj(1484006400, 'unix');
 		timestamp(1484006400).then(function(data) {
-			expect(data).toEqual({unix: 1484006400, natural: 'January 10, 2017'});
+			expect(data).toEqual(expectation);
 			done();
 		});
 	});
@@ -23,14 +51,16 @@ describe('timestamp', function () {
 
 	it('given "1484092799" returns an object with "unix" value of "1484092799" and a natural value of "January 10, 2017"', function (done) {
 		timestamp(1484092799).then(function(data) {
-			expect(data).toEqual({unix: 1484092799, natural: 'January 10, 2017'});
+			var expectation = createDateTestObj(1484092799, 'unix');
+			expect(data).toEqual(expectation);
 			done();
 		});
 	});
 
 	it('given "January 10, 2017" returns an object with "unix" value of "1484006400" and a "natural" value of "January 10, 2017"', function (done) {
+		var expectation = createDateTestObj('January 10, 2017', 'natural');
 		timestamp('January 10, 2017').then(function(data) {
-			expect(data).toEqual({unix: 1484006400, natural: 'January 10, 2017'});
+			expect(data).toEqual(expectation);
 			done();
 		});
 	});

--- a/spec/timestampSpec.js
+++ b/spec/timestampSpec.js
@@ -1,0 +1,37 @@
+var timestamp = require('../app/api/timestamp.js');
+
+describe('timestamp', function () {
+	it('returns an object', function() {
+		var result = timestamp();
+		expect(typeof(result)).toEqual('object');
+	});
+
+	it('given no agrument returns an object with keys unix and natural with null values', function (done) {
+		timestamp().then(function(data) {
+			expect(data).toEqual({unix: null, natural: null});
+			done();
+		});
+	})
+
+	it('given "1484006400" returns an object with "unix" value of "1484006400" and a natural value of "January 10, 2017"', function (done) {
+		timestamp(1484006400).then(function(data) {
+			expect(data).toEqual({unix: 1484006400, natural: 'January 10, 2017'});
+			done();
+		});
+	});
+
+
+	it('given "1484092799" returns an object with "unix" value of "1484092799" and a natural value of "January 10, 2017"', function (done) {
+		timestamp(1484092799).then(function(data) {
+			expect(data).toEqual({unix: 1484092799, natural: 'January 10, 2017'});
+			done();
+		});
+	});
+
+	it('given "January 10, 2017" returns an object with "unix" value of "1484006400" and a "natural" value of "January 10, 2017"', function (done) {
+		timestamp('January 10, 2017').then(function(data) {
+			expect(data).toEqual({unix: 1484006400, natural: 'January 10, 2017'});
+			done();
+		});
+	});
+});


### PR DESCRIPTION
…reate timestampSpec.js and write 5 unit tests.

@KasaiMagi So I wrote these tests assuming the api would return time stamps in UTC. Several tests fail and I've discovered the time stamps returned by my api are in whatever timezone my computer is set to, and I don't mind that, actually I prefer having it return time stamps in the local timezone. This will make testing a bit more difficult since one could run these tests from anywhere in the world. 